### PR TITLE
Support feature names xgboost considers illegal

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.3
+current_version = 0.0.4
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         include=["xgboost_label_encoding", "xgboost_label_encoding.*"]
     ),
     python_requires=">=3.8",
-    version="0.0.3",
+    version="0.0.4",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",

--- a/tests/test_xgboost_with_label_encoding.py
+++ b/tests/test_xgboost_with_label_encoding.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import sklearn.base
 import pytest
+from sklearn.datasets import make_classification
 
 from xgboost_label_encoding import (
     XGBoostClassifierWithLabelEncoding,
@@ -49,8 +50,8 @@ def test_xgboost_label_encoding(data):
         objective="multi:softprob",
     ).fit(X, y)
     assert np.array_equal(clf.classes_, ["Covid", "HIV", "Healthy"])
-    assert clf.predict(X).shape == (5,)
-    assert clf.predict_proba(X).shape == (5, 3)
+    assert clf.predict(X).shape == (len(y),)
+    assert clf.predict_proba(X).shape == (len(y), 3)
     assert all(predicted_label in clf.classes_ for predicted_label in clf.predict(X))
     # Confirm again that cloning works, even after a real fit
     sklearn.base.clone(clf)
@@ -60,22 +61,21 @@ def test_has_other_sklearn_properties(data):
     X, y = data
     # set feature names
     X = X.rename(columns=lambda s: f"col{s}")
+    assert np.array_equal(X.columns, ["col0", "col1", "col2", "col3", "col4"])
 
     # Fit without feature names first
     clf = XGBoostClassifierWithLabelEncoding(
         n_estimators=10,
     ).fit(X.values, y)
-    assert clf.n_features_in_ == 5
+    assert clf.n_features_in_ == X.shape[1]
     assert not hasattr(clf, "feature_names_in_")
 
     # Fit with feature names
     clf = clf.fit(X, y)
-    assert clf.n_features_in_ == 5
-    assert np.array_equal(
-        clf.feature_names_in_, ["col0", "col1", "col2", "col3", "col4"]
-    )
+    assert clf.n_features_in_ == X.shape[1]
+    assert np.array_equal(clf.feature_names_in_, X.columns)
 
-    assert clf.feature_importances_.shape == (5,)
+    assert clf.feature_importances_.shape == (X.shape[1],)
 
 
 # Sanity check that we don't need to set objective
@@ -85,8 +85,8 @@ def test_fit_multiclass_without_specifying_objective(data):
         n_estimators=10,
     ).fit(X, y)
     assert np.array_equal(clf.classes_, ["Covid", "HIV", "Healthy"])
-    assert clf.predict(X).shape == (5,)
-    assert clf.predict_proba(X).shape == (5, 3)
+    assert clf.predict(X).shape == (len(y),)
+    assert clf.predict_proba(X).shape == (len(y), 3)
     assert all(predicted_label in clf.classes_ for predicted_label in clf.predict(X))
 
 
@@ -96,8 +96,8 @@ def test_fit_binary_without_specifying_objective(data_binary):
         n_estimators=10,
     ).fit(X_binary, y_binary)
     assert np.array_equal(clf.classes_, ["HIV", "Healthy"])
-    assert clf.predict(X_binary).shape == (5,)
-    assert clf.predict_proba(X_binary).shape == (5, 2)
+    assert clf.predict(X_binary).shape == (len(y_binary),)
+    assert clf.predict_proba(X_binary).shape == (len(y_binary), 2)
     assert all(
         predicted_label in clf.classes_ for predicted_label in clf.predict(X_binary)
     )
@@ -117,9 +117,103 @@ def test_class_weight_parameter_hidden_from_inner_xgboost(data):
 
     assert clf.class_weight == "balanced"
     assert "class_weight" not in clf.get_xgb_params()
+    assert "_original_feature_names_" not in clf.get_xgb_params()
+    assert "_transformed_feature_names_" not in clf.get_xgb_params()
 
     # Confirm again after cloning
     clf = sklearn.base.clone(clf)
     clf = clf.fit(X, y)
     assert clf.class_weight == "balanced"
     assert "class_weight" not in clf.get_xgb_params()
+
+
+def test_fit_with_illegal_feature_names():
+    # Create a simple classification problem
+    # Include forbidden characters in column names
+    # "feature_names must be string, and may not contain [, ] or <"
+    original_column_names = ["col[0]", "col]1", "col<2", "col3"]
+    X, y = make_classification(n_samples=100, n_features=len(original_column_names))
+    X = pd.DataFrame(X, columns=original_column_names)
+    assert np.array_equal(X.columns, original_column_names)
+
+    # Initialize the classifier
+    clf = XGBoostClassifierWithLabelEncoding()
+
+    # Fit the model
+    clf.fit(X, y)
+
+    # Check that the original feature names are preserved
+    assert np.array_equal(
+        clf.feature_names_in_, X.columns
+    ), "Original feature names are not preserved correctly."
+
+    # Check that the renaming occurred in the inner fitted model: access the feature names from the inner model
+    inner_model_feature_names = clf.get_booster().feature_names
+    assert np.array_equal(clf._transformed_feature_names_, inner_model_feature_names)
+    for transformed in inner_model_feature_names:
+        assert (
+            "[" not in transformed and "," not in transformed and "<" not in transformed
+        ), "Forbidden character found in transformed feature names."
+
+    # Check that predict functions work with the original feature names
+    predictions = clf.predict(X)
+    assert len(predictions) == len(
+        y
+    ), "Predict function does not return the correct number of predictions."
+    prob_predictions = clf.predict_proba(X)
+    assert prob_predictions.shape == (
+        len(y),
+        2,
+    ), "Predict_proba function does not return probabilities in expected shape."
+    assert np.array_equal(
+        clf._transform_input(X).columns, inner_model_feature_names
+    ), "Transformed feature names do not match the inner model."
+
+
+def test_unique_renaming_of_columns():
+    # Create a DataFrame where columns would have the same name after forbidden character removal
+    # Renaming replaces [, ] and < with _
+    cols = [
+        "col[0]",
+        "col[0<",
+        "col[0[]",
+        "col<0>",
+        "col0",
+        "col_0_",
+        "col_0_1",
+        "col_0__1",
+        "col_0___1",
+    ]
+    X, y = make_classification(n_samples=100, n_features=len(cols))
+    X = pd.DataFrame(X, columns=cols)
+    clf = XGBoostClassifierWithLabelEncoding()
+
+    # Fit the classifier
+    clf.fit(X, y)
+
+    # Retrieve the transformed feature names from the inner model (see xgboost original implementation)
+    transformed_feature_names = clf.get_booster().feature_names
+
+    # Check that all transformed feature names are unique
+    assert len(set(transformed_feature_names)) == len(
+        transformed_feature_names
+    ), "Transformed feature names are not unique."
+    assert np.array_equal(
+        transformed_feature_names,
+        [
+            "col_0__1_1",
+            "col_0__1_1_1",
+            "col_0__",
+            "col_0>",
+            "col0",
+            "col_0_",
+            "col_0_1",
+            "col_0__1",
+            "col_0___1",
+        ],
+    ), transformed_feature_names[-2:]
+
+    # Ensure the original names are still intact
+    assert np.array_equal(
+        clf.feature_names_in_, X.columns
+    ), "The preserved feature names do not match the original."

--- a/xgboost_label_encoding/__init__.py
+++ b/xgboost_label_encoding/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Maxim Zaslavsky"""
 __email__ = "maxim@maximz.com"
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging
@@ -11,6 +11,8 @@ from logging import NullHandler
 logging.getLogger(__name__).addHandler(NullHandler())
 
 import numpy as np
+import pandas as pd
+import re
 from sklearn.preprocessing import LabelEncoder
 from typing import Any, Dict, Optional, Union
 from typing_extensions import Self
@@ -30,7 +32,11 @@ class XGBoostClassifierWithLabelEncoding(xgb.XGBClassifier):
 
     Additional features:
     - automatic class weight rebalancing as in sklearn
+    - automatic renaming of column names passed through to xgboost to avoid xgboost error: "feature_names must be string, and may not contain [, ] or <"
     """
+
+    _original_feature_names_: Optional[np.ndarray]
+    _transformed_feature_names_: Optional[np.ndarray]
 
     def __init__(
         self, class_weight: Optional[Union[dict, str]] = None, **kwargs
@@ -40,7 +46,7 @@ class XGBoostClassifierWithLabelEncoding(xgb.XGBClassifier):
 
     def fit(
         self,
-        X: np.ndarray,
+        X: Union[np.ndarray, pd.DataFrame],
         y: np.ndarray,
         sample_weight: Optional[np.ndarray] = None,
         **kwargs,
@@ -72,6 +78,52 @@ class XGBoostClassifierWithLabelEncoding(xgb.XGBClassifier):
                 f"Training data needs to have at least 2 classes, but the data contains only one class: {self.label_encoder_.classes_[0]}"
             )
 
+        # Store original column names. Xgboost will see cleaned-up versions but this property will expose any original illegal column names.
+        # Initialize as None in case we have no column names
+        self._original_feature_names_ = None
+        self._transformed_feature_names_ = None
+
+        # Store column names if X is a pandas DataFrame, and rename as necessary
+        if isinstance(X, pd.DataFrame):
+            # Avoid error: "feature_names must be string, and may not contain [, ] or <"
+
+            # Renaming columns if X is a pandas DataFrame and contains forbidden characters
+            forbidden_chars = "[]<"
+
+            # Store original names
+            self._original_feature_names_ = X.columns.to_numpy()
+
+            # Ensure all column names are strings
+            X.columns = X.columns.map(str)
+
+            # Track new column names as we define them.
+            # Initialize with existing column names to avoid changing those unless needed
+            new_column_names = set(X.columns)
+
+            # Store rename mapping
+            column_mapping = {}
+
+            for col in X.columns:
+                new_name = re.sub(f"[{re.escape(forbidden_chars)}]", "_", col)
+                if new_name == col:
+                    # No renaming happened. Skip to next column.
+                    continue
+
+                # Rename is needed. Add to mapping.
+                # First, we need to make sure the new column name is unique.
+                # If it's not, we'll append "_1" until it is.
+                while new_name in new_column_names:
+                    # Iterate until we ensure uniqueness
+                    new_name += "_1"
+                new_column_names.add(new_name)
+                column_mapping[col] = new_name
+
+            # Execute renames
+            X = X.rename(columns=column_mapping)
+
+            # Store original names
+            self._transformed_feature_names_ = X.columns.to_numpy()
+
         # fit as usual
         super().fit(X, transformed_y, sample_weight=sample_weight, **kwargs)
 
@@ -79,8 +131,46 @@ class XGBoostClassifierWithLabelEncoding(xgb.XGBClassifier):
         self.classes_: np.ndarray = self.label_encoder_.classes_
         return self
 
-    def predict(self, X: np.ndarray) -> np.ndarray:
+    def _transform_input(self, X: Union[np.ndarray, pd.DataFrame]):
+        """Apply the same column renaming logic to the input X as was applied during fit."""
+        if isinstance(X, pd.DataFrame):
+            if (
+                self._original_feature_names_ is None
+                or self._transformed_feature_names_ is None
+            ):
+                raise ValueError(
+                    "fit() must be called before predict() or predict_proba()."
+                )
+            # Convert column names to strings and apply renaming logic
+            transformed_cols = {
+                old: new
+                for old, new in zip(
+                    self._original_feature_names_, self._transformed_feature_names_
+                )
+            }
+            X = X.rename(columns=transformed_cols)
+        return X
+
+    def predict_proba(self, X: Union[np.ndarray, pd.DataFrame]) -> np.ndarray:
+        X = self._transform_input(X)  # Apply the renaming
+        return super().predict_proba(X)
+
+    def predict(self, X: Union[np.ndarray, pd.DataFrame]) -> np.ndarray:
+        X = self._transform_input(X)  # Apply the renaming
         return self.label_encoder_.inverse_transform(super().predict(X))
+
+    @property
+    def feature_names_in_(self) -> np.ndarray:
+        """Names of features seen during :py:meth:`fit`.
+        Defined only when `X` has feature names that are all strings.
+        Overriden in our implementation to support fitting with column names that include forbidden characters. Xgboost will see cleaned-up versions but this property will expose the original illegal column names.
+        """
+        if self._original_feature_names_ is None:
+            # This is the error thrown by xgboost's original implementation in this situation:
+            raise AttributeError(
+                "`feature_names_in_` is defined only when `X` has feature names that are all strings."
+            )
+        return self._original_feature_names_  # numpy array
 
     def get_xgb_params(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
Support feature names xgboost considers illegal, by silently renaming them before sending into xgboost, while exposing original feature names through the `feature_names_in_` property.

This solves the error: `feature_names must be string, and may not contain [, ] or <`